### PR TITLE
Port fix to add apache-incubator-disclaimer-resource-bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1058,7 +1058,7 @@
             <configuration>
               <resourceBundles>
                 <resourceBundle>org.apache:apache-jar-resource-bundle:1.4</resourceBundle>
-                <resourceBundle>org.apache.apache.resources:apache-incubator-disclaimer-resource-bundle:1.2-SNAPSHOT</resourceBundle>
+                <resourceBundle>org.apache:apache-incubator-disclaimer-resource-bundle:1.1</resourceBundle>
               </resourceBundles>
             </configuration>
           </execution>


### PR DESCRIPTION
Took the fix from stack overflow https://stackoverflow.com/questions/19106892/avoid-target-and-add-disclaimer-files-while-deploying-source-packs-to-nexus#19136487
